### PR TITLE
Enemy behavior helper functions

### DIFF
--- a/src/actors.c
+++ b/src/actors.c
@@ -1480,7 +1480,6 @@ void enemy_behavior_seek(enemy_t *enemy)
 void enemy_behavior_shy(enemy_t *enemy)
 {
     uint8_t next_x, next_y;
-    uint8_t tile;
     int8_t comic_facing_enemy;
     unsigned char vcollision;
     unsigned char hcollision;
@@ -1527,12 +1526,7 @@ void enemy_behavior_shy(enemy_t *enemy)
         /* Check vertical tiles (consider enemy width when x is odd) */
         vcollision = 0;
         if (enemy->y_vel > 0) {
-            tile = get_tile_at(enemy->x, (uint8_t)(next_y + 1));
-            if (is_tile_solid(tile)) vcollision = 1;
-            if (enemy->x & 1) {
-                tile = get_tile_at(enemy->x + 1, (uint8_t)(next_y + 1));
-                if (is_tile_solid(tile)) vcollision = 1;
-            }
+            vcollision = check_vertical_enemy_map_collision(enemy->x, (uint8_t)(next_y + 1));
             if (!vcollision) {
                 enemy->y = next_y;
             } else {
@@ -1540,12 +1534,7 @@ void enemy_behavior_shy(enemy_t *enemy)
                 enemy->y_vel = -1;
             }
         } else if (enemy->y_vel < 0) {
-            tile = get_tile_at(enemy->x, next_y);
-            if (is_tile_solid(tile)) vcollision = 1;
-            if (enemy->x & 1) {
-                tile = get_tile_at(enemy->x + 1, next_y);
-                if (is_tile_solid(tile)) vcollision = 1;
-            }
+            vcollision = check_vertical_enemy_map_collision(enemy->x, next_y);
             if (!vcollision) {
                 enemy->y = next_y;
             } else {
@@ -1559,13 +1548,7 @@ void enemy_behavior_shy(enemy_t *enemy)
     if (enemy->x_vel > 0) {
         /* Moving right */
         next_x = (uint8_t)(enemy->x + 1);
-        hcollision = 0;
-        tile = get_tile_at((uint8_t)(next_x + 1), enemy->y); /* check tile at x+2 like assembly */
-        if (is_tile_solid(tile)) hcollision = 1;
-        if (enemy->y & 1) {
-            tile = get_tile_at((uint8_t)(next_x + 1), (uint8_t)(enemy->y + 1));
-            if (is_tile_solid(tile)) hcollision = 1;
-        }
+        hcollision = check_horizontal_enemy_map_collision((uint8_t)(next_x + 1), enemy->y);
         if (hcollision) {
             enemy->x_vel = -1;
         } else {
@@ -1583,13 +1566,7 @@ void enemy_behavior_shy(enemy_t *enemy)
             enemy->x_vel = 1;
         } else {
             next_x = (uint8_t)(enemy->x - 1);
-            hcollision = 0;
-            tile = get_tile_at(next_x - 1, enemy->y); /* check tile at x-1 (assembly checks x-1 then uses dec) */
-            if (is_tile_solid(tile)) hcollision = 1;
-            if (enemy->y & 1) {
-                tile = get_tile_at(next_x - 1, (uint8_t)(enemy->y + 1));
-                if (is_tile_solid(tile)) hcollision = 1;
-            }
+            hcollision = check_horizontal_enemy_map_collision(next_x - 1, enemy->y);
             if (hcollision) {
                 enemy->x_vel = 1;
             } else {


### PR DESCRIPTION
This pull request refactors enemy collision detection logic in `src/actors.c` by replacing direct tile checks with new helper functions for horizontal and vertical collision detection. This change simplifies the code, improves readability, and centralizes collision logic, making it easier to maintain and update in the future.

**Collision detection refactoring:**

* Replaced all instances of direct tile lookup and solid checks using `get_tile_at` and `is_tile_solid` with calls to `check_horizontal_enemy_map_collision` and `check_vertical_enemy_map_collision` in enemy behavior functions (`enemy_behavior_bounce`, `enemy_behavior_leap`, `enemy_behavior_seek`, `enemy_behavior_shy`). [[1]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1046-R1045) [[2]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1063-R1061) [[3]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1083-R1080) [[4]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1099-R1095) [[5]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1141-R1135) [[6]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1171-R1159) [[7]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1187-R1169) [[8]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1242-R1218) [[9]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1269-R1239) [[10]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1294-R1258) [[11]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1428-R1386) [[12]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1453-R1405) [[13]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1493-R1439) [[14]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1513-R1453) [[15]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1596-R1537) [[16]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1628-R1551) [[17]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1652-R1569)
* Removed unused local variables (`tile`) from affected functions, further streamlining the code. [[1]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1028) [[2]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1119) [[3]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1409-R1367) [[4]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1549)

These changes do not alter game logic but make the codebase cleaner and more maintainable.