### PR TITLE
Fix: Player takes damage properly after picking up shield

### DIFF
--- a/src/actors.c
+++ b/src/actors.c
@@ -94,9 +94,9 @@ static const uint8_t *get_enemy_frame(uint8_t shp_index, uint8_t anim_index, uin
 /* ===== Helper Functions ===== */
 
 /*
- * comic_takes_damage - Reduce Comic's HP and start shield/death animation
+ * comic_takes_damage - Handle damage when Comic is hit by an enemy
  * 
- * If Comic has shield, remove shield instead of losing HP.
+ * Clears any pending HP increases to prevent them from negating damage.
  * If HP is already 0 when taking damage, trigger death animation sequence.
  * If HP > 0, decrement HP (sound plays in decrement_comic_hp).
  */

--- a/src/actors.c
+++ b/src/actors.c
@@ -594,14 +594,13 @@ void handle_item(void)
                     break;
                 case ITEM_SHIELD:
                     /* Shield instantly refills HP (matches original assembly behavior).
-                     * Set comic_hp_pending_increase to fill HP from current to MAX_HP.
-                     * If already at MAX_HP, award_extra_life() awards bonus points. */
+                     * Schedule HP increase to fill from current to MAX_HP only. */
                     if (comic_hp >= MAX_HP) {
                         /* Full HP: award an extra life */
                         award_extra_life();
                     } else {
-                        /* Not full: schedule MAX_HP units of HP increase */
-                        comic_hp_pending_increase = MAX_HP;
+                        /* Not full: schedule only the missing HP increments */
+                        comic_hp_pending_increase = MAX_HP - comic_hp;
                     }
                     break;
                 case ITEM_TELEPORT_WAND:

--- a/src/actors.c
+++ b/src/actors.c
@@ -34,7 +34,6 @@ extern uint8_t comic_facing;               /* COMIC_FACING_RIGHT or COMIC_FACING
 extern uint8_t comic_firepower;            /* Number of active fireball slots (0-5) */
 extern uint8_t comic_has_corkscrew;        /* 1 if Corkscrew item collected, 0 otherwise */
 extern uint8_t comic_hp;                   /* Current hit points (0-10) */
-extern uint8_t comic_has_shield;           /* 1 if Shield item collected, 0 otherwise */
 extern uint8_t comic_has_door_key;         /* 1 if door key collected, 0 otherwise */
 extern uint8_t comic_has_teleport_wand;    /* 1 if teleport wand collected, 0 otherwise */
 extern uint8_t comic_has_lantern;          /* 1 if Lantern item collected, 0 otherwise */
@@ -103,10 +102,13 @@ static const uint8_t *get_enemy_frame(uint8_t shp_index, uint8_t anim_index, uin
  */
 static void comic_takes_damage(void)
 {
-    if (comic_has_shield) {
-        comic_has_shield = 0;
-        play_sound(SOUND_DAMAGE, 2);
-    } else if (comic_hp == 0) {
+    /* Clear any pending HP increases to prevent them from canceling out damage.
+     * Without this, if HP is being gradually filled (at game start, after respawn,
+     * or after picking up a shield), the damage would be immediately negated by
+     * the pending HP increment that happens in the same or next game tick. */
+    comic_hp_pending_increase = 0;
+    
+    if (comic_hp == 0) {
         /* HP is already 0 - Comic dies from this hit.
          * Only play SOUND_DEATH via comic_death_animation, NOT SOUND_DAMAGE.
          * This matches assembly behavior: no decrement_comic_hp() call here. */
@@ -591,15 +593,15 @@ void handle_item(void)
                     comic_has_lantern = 1;
                     break;
                 case ITEM_SHIELD:
-                    comic_has_shield = 1;
-                    /* Check if Comic already has full HP */
+                    /* Shield instantly refills HP (matches original assembly behavior).
+                     * Set comic_hp_pending_increase to fill HP from current to MAX_HP.
+                     * If already at MAX_HP, award_extra_life() awards bonus points. */
                     if (comic_hp >= MAX_HP) {
                         /* Full HP: award an extra life */
                         award_extra_life();
                     } else {
-                        /* Not full: schedule only the missing HP increments
-                         * For example, if comic_hp=3 and MAX_HP=6, schedule 3 increments */
-                        comic_hp_pending_increase = MAX_HP - comic_hp;
+                        /* Not full: schedule MAX_HP units of HP increase */
+                        comic_hp_pending_increase = MAX_HP;
                     }
                     break;
                 case ITEM_TELEPORT_WAND:

--- a/src/game_main.c
+++ b/src/game_main.c
@@ -248,7 +248,6 @@ uint8_t comic_has_door_key = 0;
 uint8_t comic_has_teleport_wand = 0;
 uint8_t comic_firepower = 0;           /* Number of active fireball slots (0-5) */
 uint8_t comic_has_corkscrew = 0;       /* 1 if Corkscrew item collected */
-uint8_t comic_has_shield = 0;          /* 1 if Shield item collected */
 uint8_t comic_has_lantern = 0;         /* 1 if Lantern item collected (only affects darkness in Castle level) */
 
 /* Score - 3 bytes (24-bit value) to store up to 999,999 points */
@@ -3546,19 +3545,16 @@ static void handle_cheat_codes(void)
     
     /* S key: Grant Shield (edge-triggered on press) */
     if (key_state_cheat_shield && !previous_key_state_cheat_shield) {
-        if (comic_has_shield == 0) {
-            comic_has_shield = 1;
-            /* Check if Comic already has full HP */
-            if (comic_hp >= MAX_HP) {
-                /* Full HP: award an extra life */
-                award_extra_life();
-            } else {
-                /* Not full: schedule only the missing HP increments */
-                comic_hp_pending_increase = MAX_HP - comic_hp;
-            }
-            /* Play item collection sound for feedback */
-            play_sound(SOUND_COLLECT_ITEM, 3);
+        /* Shield instantly refills HP */
+        if (comic_hp >= MAX_HP) {
+            /* Full HP: award an extra life */
+            award_extra_life();
+        } else {
+            /* Not full: schedule HP increase */
+            comic_hp_pending_increase = MAX_HP;
         }
+        /* Play item collection sound for feedback */
+        play_sound(SOUND_COLLECT_ITEM, 3);
     }
     
     /* P key: Warp to next level (edge-triggered on press) */

--- a/src/game_main.c
+++ b/src/game_main.c
@@ -3545,7 +3545,7 @@ static void handle_cheat_codes(void)
     
     /* S key: Grant Shield (edge-triggered on press) */
     if (key_state_cheat_shield && !previous_key_state_cheat_shield) {
-        /* Shield instantly refills HP */
+        /* Shield starts an HP refill via pending increase */
         if (comic_hp >= MAX_HP) {
             /* Full HP: award an extra life */
             award_extra_life();

--- a/src/game_main.c
+++ b/src/game_main.c
@@ -3545,7 +3545,10 @@ static void handle_cheat_codes(void)
     
     /* S key: Grant Shield (edge-triggered on press) */
     if (key_state_cheat_shield && !previous_key_state_cheat_shield) {
-        /* Shield starts an HP refill via pending increase */
+        /* Shield starts an HP refill via pending increase.
+         * Note: Unlike item collection, this cheat can be used repeatedly to grant
+         * multiple extra lives if Comic is at full HP. This is intentional for testing
+         * purposes - cheat codes provide more flexible testing than item mechanics. */
         if (comic_hp >= MAX_HP) {
             /* Full HP: award an extra life */
             award_extra_life();

--- a/src/game_main.c
+++ b/src/game_main.c
@@ -3550,8 +3550,8 @@ static void handle_cheat_codes(void)
             /* Full HP: award an extra life */
             award_extra_life();
         } else {
-            /* Not full: schedule HP increase */
-            comic_hp_pending_increase = MAX_HP;
+            /* Not full: schedule only the missing HP increments */
+            comic_hp_pending_increase = MAX_HP - comic_hp;
         }
         /* Play item collection sound for feedback */
         play_sound(SOUND_COLLECT_ITEM, 3);

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -57,7 +57,6 @@ static void set_palette_register(uint8_t index, uint8_t color);
 extern uint8_t comic_has_door_key;
 extern uint8_t comic_has_teleport_wand;
 extern uint8_t comic_has_corkscrew;
-extern uint8_t comic_has_shield;
 extern uint8_t comic_has_lantern;
 extern uint8_t comic_has_gems;         /* 1 if Gems collected, 0 otherwise */
 extern uint8_t comic_has_crown;        /* 1 if Crown collected, 0 otherwise */


### PR DESCRIPTION
Remove the comic_has_shield one-hit shield feature that doesn't exist in the original assembly implementation. The original game's shield item simply refills HP gradually, without providing one-hit protection.

Fix damage mitigation bug by clearing comic_hp_pending_increase when taking damage. This prevents pending HP increases from canceling out damage on the same or subsequent game tick.

Changes:
- Remove comic_has_shield variable and related logic from actors.c, game_main.c
- Shield now instantly schedules HP refill (matching original behavior)
- Clear comic_hp_pending_increase at start of comic_takes_damage()
- Remove unused extern declarations for comic_has_shield

Fixes issue where enemy hits after picking up shield appeared to do no damage.