### PR TITLE
Fix 50k score extra-life behavior and add regression scenario

### DIFF
--- a/src/game_main.c
+++ b/src/game_main.c
@@ -3401,14 +3401,14 @@ void award_points(uint16_t points)
 {
     uint8_t carry = 0;
     uint8_t i;
-    uint8_t carried_into_second_digit = 0;
+    uint8_t carry_into_byte1 = 0;
     
     /* Add points to byte[0] with carry propagation */
     score_bytes[0] += (uint8_t)points;
     if (score_bytes[0] >= 100) {
         carry = 1;
         score_bytes[0] -= 100;
-        carried_into_second_digit = 1;
+        carry_into_byte1 = 1;
     } else {
         carry = 0;
     }
@@ -3424,15 +3424,21 @@ void award_points(uint16_t points)
         }
     }
     
-    /* If still have carry after byte 2, cap at maximum score 999,999 */
+    /* If still have carry after byte 2, cap at maximum score 999,999.
+     * Also clear carry_into_byte1: the carry that drove byte[1]
+     * above 99 did not produce a real score increment (the score has been
+     * clamped), so it must not be counted for extra-life purposes. */
     if (carry) {
         score_bytes[0] = 99;
         score_bytes[1] = 99;
         score_bytes[2] = 99;
+        carry_into_byte1 = 0;
     }
 
-    /* Match original behavior: every 5 carries into score byte 1 awards an extra life. */
-    if (carried_into_second_digit) {
+    /* Match original behavior: every 5 carries into score byte 1 awards an extra life.
+     * Guard: carry_into_byte1 is 0 when the score was clamped above, so
+     * overflow at max score never counts toward the extra-life threshold. */
+    if (carry_into_byte1) {
         score_10000_counter++;
         if (score_10000_counter >= 5) {
             score_10000_counter = 0;

--- a/src/game_main.c
+++ b/src/game_main.c
@@ -252,6 +252,8 @@ uint8_t comic_has_lantern = 0;         /* 1 if Lantern item collected (only affe
 
 /* Score - 3 bytes (24-bit value) to store up to 999,999 points */
 uint8_t score_bytes[3] = {0, 0, 0};  /* Little-endian: byte 0 is LSB, byte 2 is MSB */
+/* Counts carry events from score_bytes[0] into score_bytes[1] (every 10,000 points). */
+static uint8_t score_10000_counter = 0;
 /* Score macros (score_get_value and score_set_value) are defined in globals.h */
 
 /* Item collection tracking (per level and stage) */
@@ -3399,12 +3401,14 @@ void award_points(uint16_t points)
 {
     uint8_t carry = 0;
     uint8_t i;
+    uint8_t carried_into_second_digit = 0;
     
     /* Add points to byte[0] with carry propagation */
     score_bytes[0] += (uint8_t)points;
     if (score_bytes[0] >= 100) {
         carry = 1;
         score_bytes[0] -= 100;
+        carried_into_second_digit = 1;
     } else {
         carry = 0;
     }
@@ -3425,6 +3429,15 @@ void award_points(uint16_t points)
         score_bytes[0] = 99;
         score_bytes[1] = 99;
         score_bytes[2] = 99;
+    }
+
+    /* Match original behavior: every 5 carries into score byte 1 awards an extra life. */
+    if (carried_into_second_digit) {
+        score_10000_counter++;
+        if (score_10000_counter >= 5) {
+            score_10000_counter = 0;
+            award_extra_life();
+        }
     }
 }
 
@@ -3979,6 +3992,9 @@ void game_loop(void)
 int main(void)
 {
     int i, j;
+
+    /* Initialize score carry counter used for 50,000-point extra lives. */
+    score_10000_counter = 0;
     
     /* Initialize items_collected array */
     for (i = 0; i < 8; i++) {

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ This directory contains the validation framework for ensuring functional compati
 
 ## Functional Test Scenarios
 
-We have 5 test scenarios ordered by complexity, focused on validating core game logic:
+We have 6 test scenarios ordered by complexity, focused on validating core game logic:
 
 ### Test 1: Collision Detection (Pure Logic)
 - **Tests:** Tile collision detection, platform collision, boundary checking
@@ -38,6 +38,12 @@ We have 5 test scenarios ordered by complexity, focused on validating core game 
 - **Validation:** Enter door, verify new level loads correctly, exit and return to original level
 - **Example:** Level state should be preserved when revisiting
 
+### Test 6: Score-Based Extra Life (Regression)
+- **Tests:** Extra life award every 50,000 points via score carry counter
+- **Why Added:** Prevent regression of assembly-accurate life award behavior
+- **Validation:** Verify no life award before 50,000 and exactly one life award at each 50,000 boundary
+- **Example:** Score 49,900 -> no life; score 50,000 -> +1 life
+
 ## Directory Structure
 
 ```
@@ -49,7 +55,8 @@ tests/
 │   ├── scenario_2_init.md        # Game initialization test description
 │   ├── scenario_3_items.md       # Item collection test description
 │   ├── scenario_4_enemy.md       # Enemy behavior test description
-│   └── scenario_5_transitions.md # Level transition test description
+│   ├── scenario_5_transitions.md # Level transition test description
+│   └── scenario_6_score_extra_life.md # Score carry / extra life regression test
 ├── savestates/                   # DOSBox-X save states (for checkpoint testing)
 │   ├── level1_start.sav          # Player spawned, ready to test
 │   ├── level1_with_enemy.sav     # Enemy present for testing

--- a/tests/scenarios/scenario_6_score_extra_life.md
+++ b/tests/scenarios/scenario_6_score_extra_life.md
@@ -1,0 +1,115 @@
+# Test Scenario 6: Score-Based Extra Life (50,000-Point Regression)
+
+## Purpose
+Verify that the C implementation matches original assembly behavior for score-based extra lives:
+- Increment an internal counter when scoring carries into the ten-thousands digit.
+- Award exactly one extra life every 5 such carries (every 50,000 points).
+
+This scenario guards against regressions where score increases do not grant lives at 50,000-point boundaries.
+
+## Test Functions
+- award_points (score carry handling)
+- award_extra_life (life award side effects)
+
+## Prerequisite State
+Use a deterministic save state where score and lives are known and gameplay is stable (no immediate enemy/player damage).
+
+Recommended start values:
+- score = 000000
+- comic_num_lives = 3 (or any known value below max)
+- comic_hp < MAX_HP (to avoid max-life points-only path if lives become full during long runs)
+
+## Test Cases
+
+### Test 6.1: No Early Life Before 50,000
+Expected behavior: scoring below 50,000 does not award an extra life.
+
+Steps:
+1. Start from known state.
+2. Add points until score reaches 49,900 (or any value < 50,000).
+3. Record score and comic_num_lives.
+
+Validation:
+- comic_num_lives is unchanged from baseline.
+
+### Test 6.2: Life Award at 50,000
+Expected behavior: crossing to 50,000 awards exactly one life.
+
+Steps:
+1. Continue from Test 6.1 state.
+2. Add the next 100 points to reach 50,000.
+3. Record score and comic_num_lives.
+
+Validation:
+- comic_num_lives increased by exactly 1.
+- No double-award on the same threshold.
+
+### Test 6.3: No Early Second Life Before 100,000
+Expected behavior: no additional life is awarded between 50,100 and 99,900.
+
+Steps:
+1. Continue from Test 6.2 state.
+2. Add points up to any value < 100,000.
+3. Record comic_num_lives.
+
+Validation:
+- comic_num_lives unchanged from post-50,000 value.
+
+### Test 6.4: Second Life at 100,000
+Expected behavior: crossing to 100,000 awards one additional life.
+
+Steps:
+1. Continue from Test 6.3 state.
+2. Add points to reach 100,000.
+3. Record score and comic_num_lives.
+
+Validation:
+- comic_num_lives increased by exactly 1 relative to post-50,000 value.
+
+## Validation Checklist
+
+- [ ] Test 6.1: No life before 50,000 - PASS/FAIL
+- [ ] Test 6.2: One life at 50,000 - PASS/FAIL
+- [ ] Test 6.3: No extra life before 100,000 - PASS/FAIL
+- [ ] Test 6.4: One additional life at 100,000 - PASS/FAIL
+
+## Recording Results
+Document in tests/validation_log.txt:
+
+=== Scenario 6: Score-Based Extra Life (50,000 Regression) ===
+Date: YYYY-MM-DD
+Tester: [Name]
+
+Test 6.1 - No Early Life Before 50,000
+  Start Lives: [value]
+  End Score: [value]
+  End Lives: [value]
+  Status: PASS/FAIL
+
+Test 6.2 - Life Award at 50,000
+  Start Lives: [value]
+  End Score: [value]
+  End Lives: [value]
+  Expected Delta: +1
+  Actual Delta: [value]
+  Status: PASS/FAIL
+
+Test 6.3 - No Early Second Life Before 100,000
+  Start Lives: [value]
+  End Score: [value]
+  End Lives: [value]
+  Status: PASS/FAIL
+
+Test 6.4 - Second Life at 100,000
+  Start Lives: [value]
+  End Score: [value]
+  End Lives: [value]
+  Expected Delta: +1
+  Actual Delta: [value]
+  Status: PASS/FAIL
+
+Overall: X/4 PASS
+
+## Notes
+- If comic_num_lives reaches maximum during this scenario, extra-life behavior changes to the points-only path by design. Prefer a start state that keeps lives below max through 100,000.
+- Keep point increments deterministic and consistent between assembly and C runs.


### PR DESCRIPTION
This pull request adds a regression test and supporting logic to ensure the game awards an extra life every 50,000 points, accurately matching the original assembly implementation. The main changes include tracking score carries into the ten-thousands digit, awarding lives at the correct intervals, and documenting the new test scenario.

**Gameplay logic changes:**

* Added a static counter (`score_10000_counter`) in `src/game_main.c` to track carries into the ten-thousands digit of the score, incrementing it each time a carry occurs from `score_bytes[0]` into `score_bytes[1]`. When this counter reaches 5 (i.e., every 50,000 points), it resets and awards an extra life, matching the original assembly behavior. [[1]](diffhunk://#diff-b16dac50cd3bcb4e6e112fe27b04a5ab42e966bbdfbf111601431384e2ca6ce1R255-R256) [[2]](diffhunk://#diff-b16dac50cd3bcb4e6e112fe27b04a5ab42e966bbdfbf111601431384e2ca6ce1R3404-R3411) [[3]](diffhunk://#diff-b16dac50cd3bcb4e6e112fe27b04a5ab42e966bbdfbf111601431384e2ca6ce1R3433-R3441)
* Initialized `score_10000_counter` at program start to ensure correct behavior on new games or resets.

**Testing framework updates:**

* Added a sixth test scenario to `tests/README.md` and created `tests/scenarios/scenario_6_score_extra_life.md` to document and validate the score-based extra life behavior, including step-by-step instructions and validation criteria. [[1]](diffhunk://#diff-dacac2ebf9792f0d23c0f922a744486ded01901957d5281290925acd89cf83acL9-R9) [[2]](diffhunk://#diff-dacac2ebf9792f0d23c0f922a744486ded01901957d5281290925acd89cf83acR41-R46) [[3]](diffhunk://#diff-3c7a8b17496f67843279c4ea4821f7ab7026e5c73b7e8721f17370ee4be06b00R1-R115)
* Updated the test directory listing in `tests/README.md` to include the new scenario file.