### PR TITLE
Align teleport handling and fix item animation logic

### DIFF
--- a/docs/ASM_C_GAME_LOOP_ALIGNMENT_REVIEW_2026-04-12.md
+++ b/docs/ASM_C_GAME_LOOP_ALIGNMENT_REVIEW_2026-04-12.md
@@ -111,14 +111,12 @@ Legend: Aligned, Partial, Diverged, Intentional
   - Assembly counter advance in item rendering path: R5sw1991.asm:6507-6510
   - C toggled in item handling and incremented in swap: src/actors.c:562 and src/game_main.c:2568-2570
 
-4. Enemy death spark underlay missing
-- Evidence:
+4. Enemy death spark underlay missing ~~**FIXED 2026-04-12**~~
+- Fix applied:
+  - Dying enemies now blit their current animation frame beneath the spark for normalized spark frames 2..4, matching the assembly flow: src/actors.c
+- Was:
   - Assembly blits enemy under spark for early spark frames: R5sw1991.asm:4824-4846
-  - C dying branch renders spark only: src/actors.c:894-956
-- Impact:
-  - Visible death animation difference.
-- Recommendation:
-  - Add enemy-under-spark render for first spark frames to match assembly.
+  - C dying branch rendered spark only: src/actors.c:894-956
 
 ## Medium Priority
 

--- a/docs/ASM_C_GAME_LOOP_ALIGNMENT_REVIEW_2026-04-12.md
+++ b/docs/ASM_C_GAME_LOOP_ALIGNMENT_REVIEW_2026-04-12.md
@@ -1,0 +1,222 @@
+# Assembly vs C Game Loop Alignment Review (2026-04-12)
+
+Scope:
+- Assembly reference: reference/disassembly/R5sw1991.asm
+- C implementation: src/game_main.c, src/physics.c, src/actors.c, src/doors.c
+- Coverage: main loop branches and all direct loop descendants (teleport, fall/jump path, doors, enemies, fireballs, items, swap)
+
+## Overall Assessment
+
+- Core structure is substantially aligned.
+- Several intentional modernization changes exist (CPU yielding, edge-triggered input, cheat hooks).
+- Multiple behavioral divergences are still present, including at least two that are likely visible in gameplay (item animation cadence and teleport tick sequencing).
+
+## Branch-by-Branch Alignment Matrix
+
+Legend: Aligned, Partial, Diverged, Intentional
+
+1. Tick wait loop and recharge logic
+- Assembly: game_loop busy-wait and recharge in wait path (R5sw1991.asm:3867-3893)
+- C: while(game_tick_flag != 1) with recharge + dos_idle (src/game_main.c:3750-3761)
+- Status: Partial (intentional CPU behavior change)
+
+2. Tick consume, win countdown, run cycle, default animation, pending HP
+- Assembly: R5sw1991.asm:3895-3930
+- C: src/game_main.c:3764-3832
+- Status: Aligned
+
+3. Teleport active gate
+- Assembly: teleport path jumps directly to non-player handlers, skipping pause/fire (R5sw1991.asm:3932-3936)
+- C: handle_teleport runs, then goto handle_nonplayer_actors skips pause/fire (src/game_main.c:3835-3853)
+- Status: Aligned (fixed 2026-04-12)
+
+4. Falling/jumping gate and return target
+- Assembly: when in air, jump to handle_fall_or_jump, then return to pause section (skip door/teleport/left/right/floor checks) (R5sw1991.asm:3938-3945 and R5sw1991.asm:4421,4441)
+- C: always calls handle_fall_or_jump in non-teleport path, then may still run door/teleport checks if landing occurred this tick (src/game_main.c:3841-3857 and src/physics.c:241)
+- Status: Diverged
+
+5. Jump input start condition
+- Assembly: level-triggered key check (R5sw1991.asm:3943-3956)
+- C: edge-triggered with previous state (src/game_main.c:3783-3791)
+- Status: Intentional
+
+6. Door activation branch
+- Assembly: exact y, x delta in [0..2], has key (R5sw1991.asm:3961-3980)
+- C: same checks in check_door_activation (src/doors.c:299-357)
+- Status: Aligned
+
+7. Teleport input branch
+- Assembly: key press + wand => begin_teleport then immediate recheck of teleport branch in same tick (R5sw1991.asm:3982-3991)
+- C: edge flag + wand => begin_teleport then handle_teleport immediately, then goto handle_nonplayer_actors (src/game_main.c:3849-3860)
+- Status: Aligned (fixed 2026-04-12)
+
+8. Left/right and floor walk-off logic
+- Assembly: R5sw1991.asm:3993-4045
+- C: src/game_main.c:3857-3910
+- Status: Aligned (with landing-gate caveat from branch 4)
+
+9. Pause and fire/meter branch
+- Assembly: pause busy-wait; fire/meter asymmetry and counter cycling (R5sw1991.asm:4047-4067)
+- C: pause uses dos_idle while waiting; meter logic matches asymmetry (src/game_main.c:3912-3950)
+- Status: Partial (pause CPU behavior intentionally modernized)
+
+10. Render + non-player + swap ordering
+- Assembly: blit map/comic, then enemies/fireballs/item, then swap (R5sw1991.asm:4069-4075)
+- C: same order plus extra UI rendering calls (src/game_main.c:3953-3971)
+- Status: Partial (extra UI work in C)
+
+11. Enemy loop structure
+- Assembly: state dispatch order spawned/despawned/dying in specific flow (R5sw1991.asm:4653-4849)
+- C: despawned, then dying, then spawned (src/actors.c:876-1031)
+- Status: Partial
+
+12. Fireball loop + collision pass
+- Assembly: movement/render pass over comic_firepower slots, then separate collision pass over MAX_NUM_FIREBALLS (R5sw1991.asm:5653-5832)
+- C: single per-slot pass over comic_firepower only, collision before render per slot (src/actors.c:381-513)
+- Status: Partial
+
+13. Item update/render path
+- Assembly: item animation counter advances in collect_item_or_blit_offscreen (R5sw1991.asm:6453-6510)
+- C: item animation counter toggles in handle_item and also advances in swap_video_buffers (src/actors.c:562 and src/game_main.c:2568-2570)
+- Status: Diverged
+
+## Confirmed Differences and Omissions
+
+## High Priority
+
+1. Teleport tick sequencing ~~differs from assembly~~ **FIXED 2026-04-12**
+- Fix applied:
+  - begin_teleport() now immediately calls handle_teleport() in same tick: src/game_main.c
+  - Both teleport-start and ongoing teleport ticks use goto handle_nonplayer_actors to skip pause/fire.
+- Was:
+  - Assembly begins teleport and immediately routes through teleport branch in same tick: R5sw1991.asm:3989-3991 and R5sw1991.asm:3932-3936
+  - C deferred handle_teleport to next loop and still ran pause/fire during teleport ticks.
+
+2. In-air return path mismatch after handle_fall_or_jump
+- Evidence:
+  - Assembly returns from physics directly to pause section (skips open/teleport/left/right/floor): R5sw1991.asm:4421 and R5sw1991.asm:4441
+  - C may still evaluate door/teleport on the same tick after landing: src/game_main.c:3844-3853
+- Impact:
+  - Landing frame can process interactions earlier than assembly.
+- Recommendation:
+  - Add a strict post-physics gate to skip open/teleport/left/right/floor path when physics was entered from an in-air state that tick.
+
+3. Item animation counter advances in two places in C
+- Evidence:
+  - Assembly counter advance in item rendering path: R5sw1991.asm:6507-6510
+  - C toggles in item handling and increments in swap: src/actors.c:562 and src/game_main.c:2568-2570
+- Impact:
+  - Effective animation cadence differs from assembly; likely faster alternation.
+- Recommendation:
+  - Keep a single source of truth for item_animation_counter advancement. Prefer matching assembly cadence by advancing only in item path.
+
+4. Enemy death spark underlay missing
+- Evidence:
+  - Assembly blits enemy under spark for early spark frames: R5sw1991.asm:4824-4846
+  - C dying branch renders spark only: src/actors.c:894-956
+- Impact:
+  - Visible death animation difference.
+- Recommendation:
+  - Add enemy-under-spark render for first spark frames to match assembly.
+
+## Medium Priority
+
+5. Enemy respawn timer semantics differ (possible off-by-one)
+- Evidence:
+  - Assembly decrements timer and spawns on underflow: R5sw1991.asm:4667-4671
+  - C decrements to zero and spawns immediately at zero: src/actors.c:880-887
+- Impact:
+  - Spawn timing may be one tick earlier in C.
+- Recommendation:
+  - Decide fidelity target; if matching assembly, replicate underflow semantics.
+
+6. Fireball processing model differs
+- Evidence:
+  - Assembly collision pass is separate and scans MAX_NUM_FIREBALLS: R5sw1991.asm:5758-5832
+  - C merges movement+collision and only iterates comic_firepower slots: src/actors.c:391 and src/actors.c:445
+- Impact:
+  - Potential frame-order differences in render/collision and edge behavior when slot count changes.
+- Recommendation:
+  - Low to medium risk. Align only if deterministic replay or frame-perfect parity is required.
+
+7. Enemy state dispatch ordering differs
+- Evidence:
+  - Assembly dispatch flow: R5sw1991.asm:4661-4664
+  - C handles dying before spawned: src/actors.c:894 then src/actors.c:957
+- Impact:
+  - Usually equivalent, but subtle frame-order changes can happen around transitions.
+- Recommendation:
+  - Consider reordering for fidelity once higher-priority issues are closed.
+
+## Intentional/Justified Differences (Keep Unless Doing Frame-Perfect Mode)
+
+1. Edge-triggered jump and teleport input
+- C uses previous key state and teleport edge flag (src/game_main.c:3783-3791 and src/game_main.c:3658)
+- Assembly is level-triggered (R5sw1991.asm:3943-3956 and R5sw1991.asm:3982-3991)
+- Keep for modern feel, unless strict authenticity mode is desired.
+
+2. CPU yielding in wait loops
+- C calls dos_idle in tick wait and pause wait (src/game_main.c:3760 and src/game_main.c:3918)
+- Assembly busy-waits.
+- Keep for system friendliness.
+
+3. Debug/testing cheat hooks
+- C includes cheat handling in loop (src/game_main.c:3774 and src/game_main.c:3586)
+- Not present in assembly loop.
+- Keep for development builds; gate out for authenticity build if needed.
+
+## Recommended Execution Plan
+
+Phase 1: Fix high-impact fidelity gaps
+1. Teleport same-tick routing:
+- After begin_teleport in loop, run teleport branch logic immediately (or structured equivalent) and skip pause/fire for that frame.
+
+2. In-air return-path fidelity:
+- Ensure handle_fall_or_jump path cannot fall through to door/teleport/movement checks on same tick.
+
+3. Item animation cadence:
+- Remove one of the two item_animation_counter updates and validate frame cadence vs assembly capture.
+
+4. Enemy death underlay:
+- Render enemy beneath spark in early spark frames.
+
+Phase 2: Timing and frame-order parity
+1. Enemy respawn timer underflow semantics.
+2. Enemy state dispatch order alignment.
+3. Fireball two-pass flow alignment (if parity tests show mismatch).
+
+Phase 3: Optional authenticity modes
+1. Keep current modern defaults.
+2. Add strict-authenticity toggle to switch:
+- edge-triggered vs level-triggered input,
+- busy-wait vs yielding behavior,
+- cheat hooks enabled/disabled.
+
+## Should These Be Changed?
+
+Guidance by objective:
+- If target is functional modern remake with good feel:
+  - Keep intentional input/CPU improvements.
+  - Fix only clearly visible divergences: item cadence, teleport sequencing, enemy death underlay.
+- If target is deterministic assembly parity:
+  - Implement all high and medium changes above and validate with save-state frame comparisons.
+
+## Suggested Validation Scenarios
+
+1. Teleport edge timing test:
+- Press teleport on first eligible frame and capture whether animation starts same tick.
+
+2. Landing-frame interaction test:
+- Land while holding open/teleport and verify whether action triggers on landing frame.
+
+3. Item blink cadence test:
+- Record item frame alternation period before/after fix.
+
+4. Enemy death visual test:
+- Confirm enemy sprite is visible under spark for early death frames.
+
+5. Enemy respawn timing test:
+- Count ticks from despawn to respawn start against assembly reference.
+
+6. Fireball collision order test:
+- Validate whether fireball appears on collision frame and compare with assembly captures.

--- a/docs/ASM_C_GAME_LOOP_ALIGNMENT_REVIEW_2026-04-12.md
+++ b/docs/ASM_C_GAME_LOOP_ALIGNMENT_REVIEW_2026-04-12.md
@@ -77,8 +77,8 @@ Legend: Aligned, Partial, Diverged, Intentional
 
 13. Item update/render path
 - Assembly: item animation counter advances in collect_item_or_blit_offscreen (R5sw1991.asm:6453-6510)
-- C: item animation counter toggles in handle_item and also advances in swap_video_buffers (src/actors.c:562 and src/game_main.c:2568-2570)
-- Status: Diverged
+- C: item animation counter advances after blit in handle_item only (src/actors.c)
+- Status: Aligned (fixed 2026-04-12)
 
 ## Confirmed Differences and Omissions
 
@@ -101,14 +101,15 @@ Legend: Aligned, Partial, Diverged, Intentional
 - Recommendation:
   - Add a strict post-physics gate to skip open/teleport/left/right/floor path when physics was entered from an in-air state that tick.
 
-3. Item animation counter advances in two places in C
-- Evidence:
+3. Item animation counter advances in two places in C ~~**FIXED 2026-04-12**~~
+- Fix applied:
+  - Removed early toggle from handle_item (was firing before collision check and on off-screen frames).
+  - Removed unconditional advance from swap_video_buffers.
+  - Counter now advances once, after the blit, in handle_item's render path only: src/actors.c
+  - Sequence now matches assembly: even frame → counter 0→1, odd frame → counter 1→2→0.
+- Was:
   - Assembly counter advance in item rendering path: R5sw1991.asm:6507-6510
-  - C toggles in item handling and increments in swap: src/actors.c:562 and src/game_main.c:2568-2570
-- Impact:
-  - Effective animation cadence differs from assembly; likely faster alternation.
-- Recommendation:
-  - Keep a single source of truth for item_animation_counter advancement. Prefer matching assembly cadence by advancing only in item path.
+  - C toggled in item handling and incremented in swap: src/actors.c:562 and src/game_main.c:2568-2570
 
 4. Enemy death spark underlay missing
 - Evidence:

--- a/src/actors.c
+++ b/src/actors.c
@@ -90,6 +90,7 @@ static void comic_takes_damage(void);
 static uint8_t is_tile_solid(uint8_t tile_id);
 static uint8_t get_tile_at(uint8_t x, uint8_t y);
 static const uint8_t *get_enemy_frame(uint8_t shp_index, uint8_t anim_index, uint8_t facing, uint16_t *out_frame_size);
+static void render_enemy_sprite(const enemy_t *enemy, uint8_t shp_index, int16_t rel_x_enemy, int16_t pixel_y);
 
 /* ===== Helper Functions ===== */
 
@@ -334,6 +335,32 @@ static const uint8_t *get_enemy_frame(uint8_t shp_index, uint8_t anim_index, uin
     }
 
     return shp_get_frame(shp_index, (uint8_t)(base_index + frame_in_seq));
+}
+
+/*
+ * render_enemy_sprite - Blit the current enemy frame if it is inside the playfield
+ */
+static void render_enemy_sprite(const enemy_t *enemy, uint8_t shp_index, int16_t rel_x_enemy, int16_t pixel_y)
+{
+    int16_t pixel_x;
+    uint16_t frame_size = 0;
+    const uint8_t *frame_ptr;
+
+    if (rel_x_enemy < 0 || rel_x_enemy > PLAYFIELD_WIDTH - 2) {
+        return;
+    }
+
+    pixel_x = (rel_x_enemy * 8) + 8;
+    frame_ptr = get_enemy_frame(shp_index, enemy->spawn_timer_and_animation, enemy->facing, &frame_size);
+    if (frame_ptr == NULL) {
+        return;
+    }
+
+    if (frame_size == 160) {
+        blit_sprite_16x16_masked((uint16_t)pixel_x, (uint16_t)pixel_y, frame_ptr);
+    } else if (frame_size == 320) {
+        blit_sprite_16x32_masked((uint16_t)pixel_x, (uint16_t)pixel_y, frame_ptr);
+    }
 }
 
 /* ===== Fireball System ===== */
@@ -867,6 +894,7 @@ void handle_enemies(void)
     int16_t pixel_x, pixel_y; /* used when rendering sparks */
     const uint8_t *spark_ptr; /* used when rendering sparks */
     uint8_t spark_frame; /* used when rendering sparks */
+    uint8_t normalized_spark_state; /* white/red spark frame normalized to white spark range */
     
     /* Reset spawn flag for this tick */
     spawned_this_tick = 0;
@@ -909,12 +937,20 @@ void handle_enemies(void)
 
             /* Declarations for rendering (C89: must appear before statements) */
             rel_x_enemy = (int16_t)((int)enemy->x - (int)camera_x);
+            normalized_spark_state = enemy->state;
+            if (normalized_spark_state >= ENEMY_STATE_RED_SPARK) {
+                normalized_spark_state = (uint8_t)(normalized_spark_state - (ENEMY_STATE_RED_SPARK - ENEMY_STATE_WHITE_SPARK));
+            }
 
             /* Render death animation (spark) - use state BEFORE incrementing */
             if (rel_x_enemy >= -1 && rel_x_enemy < PLAYFIELD_WIDTH + 1) {
                 /* Convert to pixel coordinates */
                 pixel_x = (rel_x_enemy * 8) + 8;
                 pixel_y = (enemy->y * 8) + 8;
+
+                if (normalized_spark_state <= ENEMY_STATE_WHITE_SPARK + 2) {
+                    render_enemy_sprite(enemy, enemy_shp_index[i], rel_x_enemy, pixel_y);
+                }
 
                 if (enemy->state >= ENEMY_STATE_RED_SPARK) {
                     spark_frame = (uint8_t)((enemy->state - ENEMY_STATE_RED_SPARK) % 3);
@@ -1009,33 +1045,15 @@ void handle_enemies(void)
             /* Render enemy sprite if in playfield */
             {
                 int16_t rel_x_enemy;
-                int16_t pixel_x, pixel_y;
-                uint16_t frame_size = 0;
-                const uint8_t *frame_ptr;
+                int16_t pixel_y;
                 uint8_t shp_index = enemy_shp_index[i];
                 
                 /* Calculate screen position relative to camera */
                 rel_x_enemy = (int16_t)((int)enemy->x - (int)camera_x);
                 
-                /* Check if in visible playfield (match assembly bounds: 0 to PLAYFIELD_WIDTH - 2) */
-                if (rel_x_enemy >= 0 && rel_x_enemy <= PLAYFIELD_WIDTH - 2) {
-                    /* Convert to pixel coordinates (8 pixels per game unit) + playfield offset */
-                    pixel_x = (rel_x_enemy * 8) + 8;
-                    pixel_y = (enemy->y * 8) + 8;
-
-                    frame_ptr = get_enemy_frame(shp_index, enemy->spawn_timer_and_animation, enemy->facing, &frame_size);
-                    
-                    if (frame_ptr != NULL) {
-                        if (frame_size == 160) {
-                            /* Use masked blit for 16x16 .SHP sprites */
-                            blit_sprite_16x16_masked((uint16_t)pixel_x, (uint16_t)pixel_y, frame_ptr);
-                        } else if (frame_size == 320) {
-                            blit_sprite_16x32_masked((uint16_t)pixel_x, (uint16_t)pixel_y, frame_ptr);
-                        }
-                    }
-                } else {
-                    /* Enemy is offscreen, skip rendering */
-                }
+                /* Convert to pixel coordinates (8 pixels per game unit) + playfield offset */
+                pixel_y = (enemy->y * 8) + 8;
+                render_enemy_sprite(enemy, shp_index, rel_x_enemy, pixel_y);
             }
         }
     }

--- a/src/actors.c
+++ b/src/actors.c
@@ -558,9 +558,6 @@ void handle_item(void)
         return; /* Off-screen */
     }
     
-    /* Toggle animation counter */
-    item_animation_counter = (item_animation_counter == 0) ? 1 : 0;
-    
     /* Check collision with Comic */
     x_diff = (int16_t)((int)item_x - (int)comic_x);
     y_diff = (int16_t)((int)item_y - (int)comic_y);
@@ -699,6 +696,11 @@ void handle_item(void)
 
         if (sprite_ptr != NULL) {
             blit_sprite_16x16_masked((uint16_t)pixel_x, (uint16_t)pixel_y, sprite_ptr);
+            /* Advance animation counter (0->1->0) after render, matching assembly */
+            item_animation_counter++;
+            if (item_animation_counter >= 2) {
+                item_animation_counter = 0;
+            }
         }
     }
 }

--- a/src/game_main.c
+++ b/src/game_main.c
@@ -2562,11 +2562,6 @@ void swap_video_buffers(void)
         offscreen_video_buffer_ptr = GRAPHICS_BUFFER_GAMEPLAY_A;
     }
 
-    /* Advance item animation counter (0 -> 1 -> 0) */
-    item_animation_counter++;
-    if (item_animation_counter >= 2) {
-        item_animation_counter = 0;
-    }
 }
 
 static void increment_comic_hp(void)

--- a/src/game_main.c
+++ b/src/game_main.c
@@ -3819,8 +3819,10 @@ void game_loop(void)
         /* Handle teleportation */
         if (comic_is_teleporting != 0) {
             handle_teleport();
-            /* Teleport handles its own rendering, skip rendering phase */
+            /* Match assembly (.check_teleport => handle_teleport => jmp .handle_nonplayer_actors):
+             * skip pause and fire entirely during teleport, go straight to actor handling. */
             skip_rendering = 1;
+            goto handle_nonplayer_actors;
         }
         /* Handle falling, jumping, and movement only if not teleporting */
         else {
@@ -3835,9 +3837,13 @@ void game_loop(void)
             /* Check teleport input - only if not falling/jumping and teleport key was pressed this frame */
             if (comic_is_falling_or_jumping == 0 && teleport_key_pressed && comic_has_teleport_wand != 0) {
                 begin_teleport();
-                /* begin_teleport sets comic_is_teleporting, which will be handled
-                 * at the top of the next loop iteration. Skip to actor handling. */
+                /* Match assembly (.check_teleport_input => begin_teleport => jmp .check_teleport):
+                 * execute the first teleport frame immediately in this tick, then skip
+                 * pause and fire and go straight to actor handling. */
+                handle_teleport();
                 skip_rendering = 1;
+                teleport_key_pressed = 0;
+                goto handle_nonplayer_actors;
             }
             /* Handle left/right movement - only if not falling/jumping, not teleporting,
              * and did NOT just land this tick (assembly jumps to pause after landing). */
@@ -3944,6 +3950,10 @@ void game_loop(void)
             render_comic_hp_meter();
         }
         
+        /* Label for goto from teleport branches: assembly skips pause/fire during
+         * teleport and jumps directly here (.handle_nonplayer_actors). */
+        handle_nonplayer_actors:
+
         /* Handle enemies, fireballs, and items */
         handle_enemies();
         handle_fireballs();

--- a/src/game_main.c
+++ b/src/game_main.c
@@ -3833,6 +3833,10 @@ void game_loop(void)
         /* Handle teleportation */
         if (comic_is_teleporting != 0) {
             handle_teleport();
+            /* Consume any teleport edge captured during the active teleport.
+             * Without this, the goto below bypasses the normal reset path and
+             * a stale press can trigger begin_teleport() on the first non-teleport tick. */
+            teleport_key_pressed = 0;
             /* Match assembly (.check_teleport => handle_teleport => jmp .handle_nonplayer_actors):
              * skip pause and fire entirely during teleport, go straight to actor handling. */
             skip_rendering = 1;

--- a/src/game_main.c
+++ b/src/game_main.c
@@ -3826,16 +3826,29 @@ void game_loop(void)
         }
         /* Handle falling, jumping, and movement only if not teleporting */
         else {
+            /* Snapshot whether physics will run this tick.
+             * Assembly .check_falling_or_jumping / .check_jump_input both take the
+             * jmp handle_fall_or_jump path when in air or when jump is initiated,
+             * and handle_fall_or_jump returns directly to .check_pause_input,
+             * SKIPPING .check_open_input, .check_teleport_input, .check_left_input,
+             * .check_right_input and .check_for_floor entirely.
+             * We capture this before physics so we can replicate that skip below. */
+            uint8_t was_in_air = comic_is_falling_or_jumping;
+
             /* Call physics to handle gravity and collisions (single call per frame) */
             handle_fall_or_jump();
             
-            /* Check open input (doors) - only if not falling/jumping and open key is pressed */
-            if (comic_is_falling_or_jumping == 0 && key_state_open == 1) {
+            /* Check open input (doors) - only if:
+             *   - Not currently or previously in air (assembly skips this when physics ran)
+             *   - Not falling/jumping now
+             *   - Open key is pressed */
+            if (!was_in_air && comic_is_falling_or_jumping == 0 && key_state_open == 1) {
                 check_door_activation();
             }
             
-            /* Check teleport input - only if not falling/jumping and teleport key was pressed this frame */
-            if (comic_is_falling_or_jumping == 0 && teleport_key_pressed && comic_has_teleport_wand != 0) {
+            /* Check teleport input - only if not previously in air, not falling/jumping,
+             * and teleport key was pressed this frame */
+            if (!was_in_air && comic_is_falling_or_jumping == 0 && teleport_key_pressed && comic_has_teleport_wand != 0) {
                 begin_teleport();
                 /* Match assembly (.check_teleport_input => begin_teleport => jmp .check_teleport):
                  * execute the first teleport frame immediately in this tick, then skip


### PR DESCRIPTION
This pull request focuses on improving the fidelity of the C game loop and actor handling to better match the original assembly implementation. The most significant changes address several behavioral divergences identified in a detailed alignment review, particularly in teleport sequencing, item animation cadence, and enemy death rendering. The changes also introduce code refactoring for clarity and maintainability.

**Gameplay Fidelity Fixes:**

* Teleportation logic now matches the assembly: after starting a teleport, `handle_teleport()` is executed immediately in the same tick, and the loop skips pause and fire handling by jumping directly to non-player actor processing. This ensures teleport events occur with the same timing as in the assembly version. [[1]](diffhunk://#diff-b16dac50cd3bcb4e6e112fe27b04a5ab42e966bbdfbf111601431384e2ca6ce1L3841-R3873) [[2]](diffhunk://#diff-b16dac50cd3bcb4e6e112fe27b04a5ab42e966bbdfbf111601431384e2ca6ce1R3980-R3983)
* The in-air return path after `handle_fall_or_jump()` now skips door, teleport, and movement checks on the landing frame, replicating the assembly's behavior and preventing premature interactions when landing.
* Item animation counter logic is corrected: it now advances only once, after rendering, in `handle_item()`, matching the assembly's cadence and removing redundant updates from other locations. [[1]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L561-L563) [[2]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418R726-R730) [[3]](diffhunk://#diff-b16dac50cd3bcb4e6e112fe27b04a5ab42e966bbdfbf111601431384e2ca6ce1L2567-L2571)
* Enemy death spark rendering is improved: dying enemies now render their sprite beneath the spark effect for the appropriate frames, as in the assembly, by introducing a `render_enemy_sprite()` helper and updating the death animation sequence. [[1]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418R93) [[2]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418R340-R365) [[3]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418R897) [[4]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418R940-R954) [[5]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L1010-R1056)

**Documentation and Review:**

* Adds a comprehensive alignment review document (`ASM_C_GAME_LOOP_ALIGNMENT_REVIEW_2026-04-12.md`), detailing the current state of C/assembly parity, confirmed fixes, remaining divergences, and recommendations for further improvements.

These changes collectively bring the C codebase much closer to frame-accurate parity with the original assembly, while also improving code clarity and maintainability.