### PR TITLE
Medium priority fixes

### DIFF
--- a/include/actors.h
+++ b/include/actors.h
@@ -128,7 +128,7 @@ void handle_item(void);
  * handle_enemies - Update all enemies (AI, spawning, collision, rendering)
  * 
  * For each enemy slot (4 per stage):
- *   - If despawned: decrement spawn timer, spawn when timer reaches 0
+ *   - If despawned: decrement spawn timer, spawn when timer underflows (0 -> 255)
  *   - If spawned: execute AI behavior, check collision, render
  *   - If dying: advance death animation, render spark
  * 
@@ -149,7 +149,7 @@ void handle_enemies(void);
 /*
  * maybe_spawn_enemy - Attempt to spawn one enemy
  * 
- * Helper function called by handle_enemies when an enemy's spawn timer reaches 0.
+ * Helper function called by handle_enemies when an enemy's spawn timer underflows.
  * Only spawns 1 enemy per tick to avoid overwhelming the player.
  * 
  * Returns:

--- a/include/actors.h
+++ b/include/actors.h
@@ -100,9 +100,11 @@ void try_to_fire(void);
  * 
  * For each active fireball (first comic_firepower slots):
  *   - Apply horizontal velocity (±2 per tick)
+ *   - Check despawn conditions (off-screen)
  *   - Apply corkscrew motion if Comic has Corkscrew item (vertical oscillation)
  *   - Advance animation frame
- *   - Check despawn conditions (off-screen)
+ *   - Render fireball sprite
+ * Then perform a separate collision pass over all MAX_NUM_FIREBALLS slots.
  *   - Check collision with all enemies
  *   - Award points and kill enemy on collision
  * 

--- a/include/globals.h
+++ b/include/globals.h
@@ -136,7 +136,7 @@ void debug_log_close(void);
 /* extern uint8_t tileset_graphics[]; */
 /* extern uint8_t *current_tiles_ptr; */
 
-/* Set when a stage/door transition occurs so game_loop can restart immediately
+/* Set when a stage-edge transition occurs so game_loop can restart immediately
  * like the original assembly tail-jump flow. */
 extern uint8_t stage_transitioned_this_tick;
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -136,5 +136,9 @@ void debug_log_close(void);
 /* extern uint8_t tileset_graphics[]; */
 /* extern uint8_t *current_tiles_ptr; */
 
+/* Set when a stage/door transition occurs so game_loop can restart immediately
+ * like the original assembly tail-jump flow. */
+extern uint8_t stage_transitioned_this_tick;
+
 #endif /* GLOBALS_H */
 

--- a/src/actors.c
+++ b/src/actors.c
@@ -415,16 +415,32 @@ void handle_fireballs(void)
         return;
     }
     
-    /* Update each active fireball */
+    /* Pass 1: movement + animation + render over the first comic_firepower slots */
     for (i = 0; i < comic_firepower && i < MAX_NUM_FIREBALLS; i++) {
         /* Skip inactive fireballs */
-        if (fireballs[i].x == FIREBALL_DEAD || fireballs[i].y == FIREBALL_DEAD) {
+        if (fireballs[i].x == FIREBALL_DEAD && fireballs[i].y == FIREBALL_DEAD) {
             continue;
         }
         
         /* Apply horizontal velocity */
         fireballs[i].x += fireballs[i].vel;
         
+        /* Check despawn conditions (off-screen) before corkscrew/animation */
+        if (fireballs[i].x < camera_x) {
+            /* Off left edge */
+            fireballs[i].x = FIREBALL_DEAD;
+            fireballs[i].y = FIREBALL_DEAD;
+            continue;
+        }
+
+        rel_x = (int16_t)((int)fireballs[i].x - (int)camera_x);
+        if (rel_x > (PLAYFIELD_WIDTH - 2)) {
+            /* Off right edge */
+            fireballs[i].x = FIREBALL_DEAD;
+            fireballs[i].y = FIREBALL_DEAD;
+            continue;
+        }
+
         /* Apply corkscrew motion if Comic has Corkscrew item */
         if (comic_has_corkscrew) {
             if (fireballs[i].corkscrew_phase == 2) {
@@ -443,23 +459,30 @@ void handle_fireballs(void)
         if (fireballs[i].animation >= fireballs[i].num_animation_frames) {
             fireballs[i].animation = 0;
         }
-        
-        /* Check despawn conditions (off-screen) */
-        if (fireballs[i].x < camera_x) {
-            /* Off left edge */
-            fireballs[i].x = FIREBALL_DEAD;
-            fireballs[i].y = FIREBALL_DEAD;
+
+        /* Render fireball sprite in playfield */
+        {
+            int16_t pixel_x, pixel_y;
+            const uint8_t *sprite_ptr;
+
+            pixel_x = (rel_x * 8) + 8;
+            pixel_y = (fireballs[i].y * 8) + 8;
+
+            sprite_ptr = (fireballs[i].animation == 0)
+                ? sprite_fireball_0_16x8m
+                : sprite_fireball_1_16x8m;
+
+            blit_sprite_16x8_masked((uint16_t)pixel_x, (uint16_t)pixel_y, sprite_ptr);
+        }
+    }
+
+    /* Pass 2: collision scan over all fireball slots (assembly behavior) */
+    for (i = 0; i < MAX_NUM_FIREBALLS; i++) {
+        /* Skip inactive fireballs */
+        if (fireballs[i].x == FIREBALL_DEAD && fireballs[i].y == FIREBALL_DEAD) {
             continue;
         }
-        
-        rel_x = (int16_t)((int)fireballs[i].x - (int)camera_x);
-        if (rel_x > (PLAYFIELD_WIDTH - 2)) {
-            /* Off right edge */
-            fireballs[i].x = FIREBALL_DEAD;
-            fireballs[i].y = FIREBALL_DEAD;
-            continue;
-        }
-        
+
         /* Check collision with all enemies */
         for (j = 0; j < MAX_NUM_ENEMIES; j++) {
             int8_t y_diff, x_diff;
@@ -489,28 +512,6 @@ void handle_fireballs(void)
             play_sound(SOUND_HIT_ENEMY, 1);
             
             break; /* Fireball consumed, check next fireball */
-        }
-        
-        /* Render fireball sprite if still active and in playfield */
-        if (fireballs[i].x != FIREBALL_DEAD && fireballs[i].y != FIREBALL_DEAD) {
-            int16_t pixel_x, pixel_y;
-            const uint8_t *sprite_ptr;
-            
-            /* Calculate screen position relative to camera */
-            rel_x = (int16_t)((int)fireballs[i].x - (int)camera_x);
-            
-            /* Check if in visible playfield (0-23 game units) */
-            if (rel_x >= 0 && rel_x < PLAYFIELD_WIDTH) {
-                /* Convert to pixel coordinates (8 pixels per game unit) + playfield offset */
-                pixel_x = (rel_x * 8) + 8;
-                pixel_y = (fireballs[i].y * 8) + 8;
-
-                sprite_ptr = (fireballs[i].animation == 0)
-                    ? sprite_fireball_0_16x8m
-                    : sprite_fireball_1_16x8m;
-
-                blit_sprite_16x8_masked((uint16_t)pixel_x, (uint16_t)pixel_y, sprite_ptr);
-            }
         }
     }
 }

--- a/src/actors.c
+++ b/src/actors.c
@@ -930,6 +930,9 @@ void handle_enemies(void)
                 case ENEMY_BEHAVIOR_SHY:
                     enemy_behavior_shy(enemy);
                     break;
+                default:
+                    /* Match ASM behavior: skip unknown behavior codes entirely this tick. */
+                    continue;
             }
             
             /* Check despawn distance (30 game units from Comic) */
@@ -975,11 +978,11 @@ void handle_enemies(void)
         /* Despawned state in ASM is enemy.state < ENEMY_STATE_SPAWNED. */
         if (enemy->state < ENEMY_STATE_SPAWNED) {
             /* Assembly semantics: decrement every tick and spawn on underflow
-             * (borrow from 0 -> 0xFF), not when reaching zero. */
+             * (borrow from 0 -> UINT8_MAX), not when reaching zero. */
             enemy->spawn_timer_and_animation--;
 
-            /* Attempt to spawn only on underflow (0 -> 255) */
-            if (enemy->spawn_timer_and_animation == 0xFF) {
+            /* Attempt to spawn only on underflow (0 -> UINT8_MAX) */
+            if (enemy->spawn_timer_and_animation == UINT8_MAX) {
                 maybe_spawn_enemy(i);
             }
             continue;

--- a/src/actors.c
+++ b/src/actors.c
@@ -904,24 +904,88 @@ void handle_enemies(void)
         enemy_t *enemy = &enemies[i];
         int16_t x_diff, y_diff;
         
-        /* Handle despawned state */
-        if (enemy->state == ENEMY_STATE_DESPAWNED) {
-            /* Decrement spawn timer */
-            if (enemy->spawn_timer_and_animation > 0) {
-                enemy->spawn_timer_and_animation--;
+        /* Match assembly dispatch flow: spawned, despawned, then dying. */
+        if (enemy->state == ENEMY_STATE_SPAWNED) {
+            /* Advance animation frame */
+            enemy->spawn_timer_and_animation++;
+            if (enemy->spawn_timer_and_animation >= enemy->num_animation_frames) {
+                enemy->spawn_timer_and_animation = 0;
             }
             
-            /* Attempt to spawn when timer reaches 0 */
-            if (enemy->spawn_timer_and_animation == 0) {
-                /* Always try - maybe_spawn_enemy will check the global flag
-                 * If spawn fails, timer stays at 0 and will retry next tick */
+            /* Execute AI behavior */
+            switch (enemy->behavior & ~ENEMY_BEHAVIOR_FAST) {
+                case ENEMY_BEHAVIOR_BOUNCE:
+                    enemy_behavior_bounce(enemy);
+                    break;
+                case ENEMY_BEHAVIOR_LEAP:
+                    enemy_behavior_leap(enemy);
+                    break;
+                case ENEMY_BEHAVIOR_ROLL:
+                    enemy_behavior_roll(enemy);
+                    break;
+                case ENEMY_BEHAVIOR_SEEK:
+                    enemy_behavior_seek(enemy);
+                    break;
+                case ENEMY_BEHAVIOR_SHY:
+                    enemy_behavior_shy(enemy);
+                    break;
+            }
+            
+            /* Check despawn distance (30 game units from Comic) */
+            x_diff = (int16_t)((int)enemy->x - (int)comic_x);
+            if (x_diff < -ENEMY_DESPAWN_RADIUS || x_diff > ENEMY_DESPAWN_RADIUS) {
+                enemy->state = ENEMY_STATE_DESPAWNED;
+                enemy->spawn_timer_and_animation = enemy_respawn_counter_cycle;
+                continue;
+            }
+            
+            /* Check collision with Comic */
+            y_diff = (int16_t)((int)enemy->y - (int)comic_y);
+            
+            /* Horizontal: abs(enemy.x - comic_x) < 2 */
+            if (x_diff >= -1 && x_diff <= 1) {
+                /* Vertical: 0 <= (enemy.y - comic_y) < 4 */
+                if (y_diff >= 0 && y_diff < 4) {
+                    /* Collision detected! */
+                    enemy->state = ENEMY_STATE_RED_SPARK; /* Start red spark death animation */
+                    
+                    /* Handle damage to Comic (shield loss, HP loss, or death) */
+                    comic_takes_damage();
+                    continue;
+                }
+            }
+            
+            /* Render enemy sprite if in playfield */
+            {
+                int16_t rel_x_enemy;
+                int16_t pixel_y;
+                uint8_t shp_index = enemy_shp_index[i];
+                
+                /* Calculate screen position relative to camera */
+                rel_x_enemy = (int16_t)((int)enemy->x - (int)camera_x);
+                
+                /* Convert to pixel coordinates (8 pixels per game unit) + playfield offset */
+                pixel_y = (enemy->y * 8) + 8;
+                render_enemy_sprite(enemy, shp_index, rel_x_enemy, pixel_y);
+            }
+            continue;
+        }
+
+        /* Despawned state in ASM is enemy.state < ENEMY_STATE_SPAWNED. */
+        if (enemy->state < ENEMY_STATE_SPAWNED) {
+            /* Assembly semantics: decrement every tick and spawn on underflow
+             * (borrow from 0 -> 0xFF), not when reaching zero. */
+            enemy->spawn_timer_and_animation--;
+
+            /* Attempt to spawn only on underflow (0 -> 255) */
+            if (enemy->spawn_timer_and_animation == 0xFF) {
                 maybe_spawn_enemy(i);
             }
             continue;
         }
-        
-        /* Handle dying state (white spark or red spark) */
-        if (enemy->state >= ENEMY_STATE_WHITE_SPARK && enemy->state != ENEMY_STATE_SPAWNED) {
+
+        /* Dying state: all values greater than ENEMY_STATE_SPAWNED. */
+        {
             /* If the state is the "finished" value (ENEMY_STATE_WHITE_SPARK + 5 or ENEMY_STATE_RED_SPARK + 5),
              * immediately despawn without rendering the final frame to match original assembly behavior. */
             if (enemy->state == ENEMY_STATE_WHITE_SPARK + 5 || enemy->state == ENEMY_STATE_RED_SPARK + 5) {
@@ -987,73 +1051,6 @@ void handle_enemies(void)
                 if (enemy_respawn_counter_cycle > 100) {
                     enemy_respawn_counter_cycle = 20;
                 }
-            }
-            continue;
-        }
-        
-        /* Handle spawned state */
-        if (enemy->state == ENEMY_STATE_SPAWNED) {
-            /* Advance animation frame */
-            enemy->spawn_timer_and_animation++;
-            if (enemy->spawn_timer_and_animation >= enemy->num_animation_frames) {
-                enemy->spawn_timer_and_animation = 0;
-            }
-            
-            /* Execute AI behavior */
-            switch (enemy->behavior & ~ENEMY_BEHAVIOR_FAST) {
-                case ENEMY_BEHAVIOR_BOUNCE:
-                    enemy_behavior_bounce(enemy);
-                    break;
-                case ENEMY_BEHAVIOR_LEAP:
-                    enemy_behavior_leap(enemy);
-                    break;
-                case ENEMY_BEHAVIOR_ROLL:
-                    enemy_behavior_roll(enemy);
-                    break;
-                case ENEMY_BEHAVIOR_SEEK:
-                    enemy_behavior_seek(enemy);
-                    break;
-                case ENEMY_BEHAVIOR_SHY:
-                    enemy_behavior_shy(enemy);
-                    break;
-            }
-            
-            /* Check despawn distance (30 game units from Comic) */
-            x_diff = (int16_t)((int)enemy->x - (int)comic_x);
-            if (x_diff < -ENEMY_DESPAWN_RADIUS || x_diff > ENEMY_DESPAWN_RADIUS) {
-                enemy->state = ENEMY_STATE_DESPAWNED;
-                enemy->spawn_timer_and_animation = enemy_respawn_counter_cycle;
-                continue;
-            }
-            
-            /* Check collision with Comic */
-            y_diff = (int16_t)((int)enemy->y - (int)comic_y);
-            
-            /* Horizontal: abs(enemy.x - comic_x) < 2 */
-            if (x_diff >= -1 && x_diff <= 1) {
-                /* Vertical: 0 <= (enemy.y - comic_y) < 4 */
-                if (y_diff >= 0 && y_diff < 4) {
-                    /* Collision detected! */
-                    enemy->state = ENEMY_STATE_RED_SPARK; /* Start red spark death animation */
-                    
-                    /* Handle damage to Comic (shield loss, HP loss, or death) */
-                    comic_takes_damage();
-                    continue;
-                }
-            }
-            
-            /* Render enemy sprite if in playfield */
-            {
-                int16_t rel_x_enemy;
-                int16_t pixel_y;
-                uint8_t shp_index = enemy_shp_index[i];
-                
-                /* Calculate screen position relative to camera */
-                rel_x_enemy = (int16_t)((int)enemy->x - (int)camera_x);
-                
-                /* Convert to pixel coordinates (8 pixels per game unit) + playfield offset */
-                pixel_y = (enemy->y * 8) + 8;
-                render_enemy_sprite(enemy, shp_index, rel_x_enemy, pixel_y);
             }
         }
     }

--- a/src/doors.c
+++ b/src/doors.c
@@ -233,15 +233,17 @@ void exit_door_animation(void)
                    (PLAYFIELD_OFFSET_X / 8) + camera_relative_x;
     door_blit_offset = pixel_offset;
     
-    /* Initial delay */
-    wait_n_ticks(3);
-    
     /* Play door sound */
     play_sound(SOUND_DOOR, 4);
     
-    /* Frame 1: Door fully closed */
+    /* Frame 1: Door fully closed - render new stage map immediately so it's
+     * visible before the initial delay (prevents the previous stage's final
+     * frame from lingering on screen during the wait). */
     blit_map_playfield_offscreen();
     wait_1_tick_and_swap();
+    
+    /* Initial delay after first frame is visible */
+    wait_n_ticks(2);
     
     /* Frame 2: Door halfway open (Comic behind door) */
     blit_map_playfield_offscreen();

--- a/src/doors.c
+++ b/src/doors.c
@@ -233,17 +233,15 @@ void exit_door_animation(void)
                    (PLAYFIELD_OFFSET_X / 8) + camera_relative_x;
     door_blit_offset = pixel_offset;
     
+    /* Assembly waits 3 ticks before starting door SFX/animation. */
+    wait_n_ticks(3);
+
     /* Play door sound */
     play_sound(SOUND_DOOR, 4);
     
-    /* Frame 1: Door fully closed - render new stage map immediately so it's
-     * visible before the initial delay (prevents the previous stage's final
-     * frame from lingering on screen during the wait). */
+    /* Frame 1: Door fully closed */
     blit_map_playfield_offscreen();
     wait_1_tick_and_swap();
-    
-    /* Initial delay after first frame is visible */
-    wait_n_ticks(2);
     
     /* Frame 2: Door halfway open (Comic behind door) */
     blit_map_playfield_offscreen();
@@ -260,6 +258,8 @@ void exit_door_animation(void)
     
     /* Frame 4: Door halfway closed (Comic in front) */
     blit_map_playfield_offscreen();
+    /* Keep the assembly's redundant draw order for frame-exact behavior. */
+    blit_door_halfopen_offscreen();
     blank_door_offscreen();
     blit_door_halfopen_offscreen();
     blit_comic_playfield_offscreen();

--- a/src/game_main.c
+++ b/src/game_main.c
@@ -187,6 +187,8 @@ uint8_t comic_hp_pending_increase = MAX_HP;  /* Fill HP at game start */
 uint16_t camera_x = 0;
 /* Landing sentinel: set by physics when hitting ground; clears each tick */
 uint8_t landed_this_tick = 0;
+/* Set by movement/door code when stage changes mid-tick. */
+uint8_t stage_transitioned_this_tick = 0;
 
 /* Death animation state - prevents re-entering death animation during enemy collisions */
 uint8_t inhibit_death_by_enemy_collision = 0;
@@ -3846,7 +3848,12 @@ void game_loop(void)
              *   - Not falling/jumping now
              *   - Open key is pressed */
             if (!was_in_air && comic_is_falling_or_jumping == 0 && key_state_open == 1) {
-                check_door_activation();
+                if (check_door_activation()) {
+                    /* Match assembly .check_open_input -> jmp activate_door:
+                     * do not continue pause/fire/render logic in this tick. */
+                    teleport_key_pressed = 0;
+                    continue;
+                }
             }
             
             /* Check teleport input - only if not previously in air, not falling/jumping,
@@ -3917,6 +3924,12 @@ void game_loop(void)
             
             /* Clear the teleport flag after checking */
             teleport_key_pressed = 0;
+        }
+
+        if (stage_transitioned_this_tick) {
+            /* Match assembly stage_edge_transition -> jmp load_new_stage -> jmp game_loop. */
+            stage_transitioned_this_tick = 0;
+            continue;
         }
         
         /* Check escape key (pause) */

--- a/src/game_main.c
+++ b/src/game_main.c
@@ -187,7 +187,7 @@ uint8_t comic_hp_pending_increase = MAX_HP;  /* Fill HP at game start */
 uint16_t camera_x = 0;
 /* Landing sentinel: set by physics when hitting ground; clears each tick */
 uint8_t landed_this_tick = 0;
-/* Set by movement/door code when stage changes mid-tick. */
+/* Set by stage-edge movement code when a stage change occurs mid-tick. */
 uint8_t stage_transitioned_this_tick = 0;
 
 /* Death animation state - prevents re-entering death animation during enemy collisions */

--- a/src/game_main.c
+++ b/src/game_main.c
@@ -397,6 +397,7 @@ static void clear_bios_keyboard_buffer(void);
 static void clear_scancode_queue(void);
 static void update_keyboard_input(void);
 static void handle_cheat_codes(void);
+static void dos_idle(void);
 static void game_over(void);
 static void do_high_scores(void);
 static void game_end_sequence(void);
@@ -429,27 +430,18 @@ void disable_pc_speaker(void)
  *   ticks = number of ticks to wait
  * Output:
  *   game_tick_flag is set to 0
- * 
- * Uses DOS INT 1Ah to read the system timer for timing.
  */
 void wait_n_ticks(uint16_t ticks)
 {
-    union REGS regs;
-    uint32_t start_ticks, current_ticks;
-    
-    /* Get starting tick count from BIOS */
-    regs.h.ah = 0x00;  /* AH=0x00: read system timer */
-    int86(0x1A, &regs, &regs);
-    start_ticks = ((uint32_t)regs.w.cx << 16) | regs.w.dx;
-    
-    /* Wait for the requested number of ticks to elapse */
-    do {
-        regs.h.ah = 0x00;
-        int86(0x1A, &regs, &regs);
-        current_ticks = ((uint32_t)regs.w.cx << 16) | regs.w.dx;
-    } while ((current_ticks - start_ticks) < ticks);
-    
-    game_tick_flag = 0;
+    while (ticks > 0) {
+        while (game_tick_flag != 1) {
+            /* Match game-loop wait behavior while yielding CPU between IRQ0 updates. */
+            dos_idle();
+        }
+
+        game_tick_flag = 0;
+        ticks--;
+    }
 }
 
 /*
@@ -2909,13 +2901,6 @@ void load_new_stage(void)
     
     /* Pre-render the entire map into RENDERED_MAP_BUFFER */
     render_map();
-
-    /* Ensure the initial frame is drawn and displayed: replicate the
-     * assembly behavior of blitting and swapping buffers at load time. */
-    blit_map_playfield_offscreen();
-    /* Skip blitting Comic here - if doing beam_in, Comic should not be visible yet;
-     * if not doing beam_in (entering via door), the game loop will render Comic normally */
-    swap_video_buffers();
 
 #ifdef ENABLE_SHP_SMOKE_TEST
     /* Smoke test: if a 16x32 SHP frame is loaded for shp index 0, blit its

--- a/src/game_main.c
+++ b/src/game_main.c
@@ -2316,6 +2316,8 @@ void blit_map_playfield_offscreen(void)
     const uint16_t max_camera_x = rendered_bytes_per_row - playfield_bytes_per_row; /* 232 */
     uint8_t plane;
     uint16_t row;
+    uint16_t src_start;
+    uint16_t dst_start;
 
     /* Validate camera position is within rendered map bounds.
      * If camera_x exceeds max_camera_x, the max_src_bytes calculation would underflow.
@@ -2326,46 +2328,25 @@ void blit_map_playfield_offscreen(void)
         return;
     }
 
+    src_start = RENDERED_MAP_BUFFER + camera_x;
+    dst_start = offscreen_video_buffer_ptr + (8 * screen_bytes_per_row) + (8 / 8);
+
     for (plane = 0; plane < 4; plane++) {
         /* Enable reading and writing for this plane */
         enable_ega_plane_read_write(plane);
 
-        for (row = 0; row < playfield_pixel_rows; row++) {
-            /* Source offset calculation using larger type to prevent overflow
-             * Max value: 0x4000 + (159 * 256) + camera_x ≈ 57K, fits in uint16_t
-             * but use unsigned long for intermediate to be safe */
-            unsigned long src_calc = RENDERED_MAP_BUFFER + ((unsigned long)row * rendered_bytes_per_row) + camera_x;
-            uint16_t src_offset;
-            uint16_t dst_offset;
-            uint16_t max_src_bytes;
-            uint16_t bytes_to_copy;
-            
-            /* Validate calculation fits within segment before assigning to uint16_t */
-            if (src_calc > 65535UL) {
-                /* Source offset would overflow; skip this row */
-                continue;
-            }
-            src_offset = (uint16_t)src_calc;
-            
-            dst_offset = offscreen_video_buffer_ptr + ((8 + row) * screen_bytes_per_row) + (8 / 8);
+        {
+            uint8_t __far *src_row = (uint8_t __far *)MK_FP(VIDEO_MEMORY_BASE, src_start);
+            uint8_t __far *dst_row = (uint8_t __far *)MK_FP(VIDEO_MEMORY_BASE, dst_start);
 
-            /* Calculate maximum bytes available to read from this row.
-             * Formula: remaining bytes in row = row_start + 256 - src_offset_within_row
-             * Which simplifies to: (256 - camera_x - 0) = 256 - camera_x bytes available
-             * for the first row. But this depends on the row number in the rendered buffer.
-             * 
-             * Safer approach: bytes available = bytes from camera_x to end of rendered row
-             * = rendered_bytes_per_row - camera_x = 256 - camera_x
-             * (This is constant across all rows since stride is uniform) */
-            max_src_bytes = rendered_bytes_per_row - camera_x;
-            
-            bytes_to_copy = playfield_bytes_per_row;
-            if (bytes_to_copy > max_src_bytes) {
-                bytes_to_copy = max_src_bytes;
+            for (row = 0; row < playfield_pixel_rows; row++) {
+                uint8_t col;
+                for (col = 0; col < playfield_bytes_per_row; col++) {
+                    dst_row[col] = src_row[col];
+                }
+                src_row += rendered_bytes_per_row;
+                dst_row += screen_bytes_per_row;
             }
-
-            /* Copy the row for this plane using helper that performs far-pointer copy */
-            copy_plane_bytes(src_offset, dst_offset, bytes_to_copy);
         }
     }
 }
@@ -2697,50 +2678,38 @@ static void blit_tile_to_map(uint8_t tile_id, uint8_t tile_x, uint8_t tile_y, co
  */
 static void render_map(void)
 {
-    uint8_t tile_x;
-    uint8_t tile_y;
-    uint16_t tile_index;
-    uint8_t tile_id;
     uint8_t plane;
-    uint16_t clear_offset;
-    uint16_t clear_row;
-    uint8_t __far *clear_ptr;
-    uint16_t i;
-    
+    uint8_t tile_y;
+    uint8_t tile_x;
+    uint8_t pixel_row;
+    uint16_t map_row_base;
+    uint16_t src_offset;
+    uint16_t dst_offset;
+    uint8_t tile_id;
+    const uint8_t *tile_map_row;
+    uint8_t __far *dst_row;
 
+    /* Render directly into all 160x256 bytes per plane. No explicit clear pass is
+     * needed because every byte in the rendered-map region is overwritten below. */
     for (plane = 0; plane < 4; plane++) {
-        /* Set Sequencer Map Mask for this plane */
-        outp(0x3c4, 0x02);      /* SC Index: Map Mask */
+        outp(0x3c4, 0x02);       /* SC Index: Map Mask */
         outp(0x3c5, 1 << plane); /* SC Data: plane mask */
-        
-        /* Clear all rows of this plane */
-        for (clear_row = 0; clear_row < 160; clear_row++) {
-            clear_offset = RENDERED_MAP_BUFFER + (clear_row * 256);
-            clear_ptr = (uint8_t __far *)MK_FP(VIDEO_MEMORY_BASE, clear_offset);
-            
-            /* Write 256 bytes of zero to this row */
-            for (i = 0; i < 256; i++) {
-                clear_ptr[i] = 0;
+
+        for (tile_y = 0; tile_y < MAP_HEIGHT_TILES; tile_y++) {
+            map_row_base = (uint16_t)tile_y * MAP_WIDTH_TILES;
+            tile_map_row = (current_tiles_ptr != NULL) ? (current_tiles_ptr + map_row_base) : NULL;
+
+            for (pixel_row = 0; pixel_row < 16; pixel_row++) {
+                dst_offset = RENDERED_MAP_BUFFER + (((uint16_t)tile_y * 16 + pixel_row) << 8);
+                dst_row = (uint8_t __far *)MK_FP(VIDEO_MEMORY_BASE, dst_offset);
+
+                for (tile_x = 0; tile_x < MAP_WIDTH_TILES; tile_x++) {
+                    tile_id = (tile_map_row != NULL) ? tile_map_row[tile_x] : 0;
+                    src_offset = (uint16_t)tile_id * 128 + (uint16_t)plane * 32 + (uint16_t)pixel_row * 2;
+                    *dst_row++ = tileset_graphics[src_offset + 0];
+                    *dst_row++ = tileset_graphics[src_offset + 1];
+                }
             }
-        }
-    }
-    
-    /* Iterate through all tiles in the map (128×10) */
-    for (tile_y = 0; tile_y < MAP_HEIGHT_TILES; tile_y++) {
-        for (tile_x = 0; tile_x < MAP_WIDTH_TILES; tile_x++) {
-            /* Calculate index into tile map, casting to uint16_t to avoid overflow:
-             * tile_y (0-9) * MAP_WIDTH_TILES (128) + tile_x (0-127) = 0-1279 */
-            tile_index = (uint16_t)tile_y * MAP_WIDTH_TILES + tile_x;
-            
-            /* Get tile ID from current level's tile map */
-            if (current_tiles_ptr != NULL) {
-                tile_id = current_tiles_ptr[tile_index];
-            } else {
-                tile_id = 0;  /* No map loaded */
-            }
-            
-            /* Blit this tile to the rendered map buffer */
-            blit_tile_to_map(tile_id, tile_x, tile_y, tileset_graphics);
         }
     }
 }

--- a/src/physics.c
+++ b/src/physics.c
@@ -39,6 +39,7 @@ extern uint16_t camera_x;
 extern uint8_t landed_this_tick;
 extern uint8_t comic_y_checkpoint;
 extern uint8_t comic_x_checkpoint;
+extern uint8_t stage_transitioned_this_tick;
 
 /* External input state (set by keyboard handling in game_main.c) */
 extern uint8_t key_state_jump;
@@ -286,6 +287,7 @@ void move_left(void)
         comic_y_checkpoint = comic_y;
         comic_x_checkpoint = MAP_WIDTH - 2;
         comic_x = MAP_WIDTH - 2;
+        stage_transitioned_this_tick = 1;
         load_new_stage();
         return;
     }
@@ -354,6 +356,7 @@ void move_right(void)
         comic_y_checkpoint = comic_y;
         comic_x_checkpoint = 0;
         comic_x = 0;
+        stage_transitioned_this_tick = 1;
         load_new_stage();
         return;
     }


### PR DESCRIPTION
This pull request refactors the fireball and enemy handling logic to more closely match the original assembly game's behavior, clarifies documentation, and improves code correctness and readability. The most significant changes are the restructuring of the fireball update/collision/render logic, the correction of enemy spawn timer semantics, and the reordering of enemy state handling for accuracy.

**Fireball handling improvements:**

* Refactored `handle_fireballs` to separate fireball processing into two passes: the first pass updates movement, animation, and rendering for active fireballs, and the second pass checks for collisions across all fireballs, matching original assembly logic. [[1]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L418-R443) [[2]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L447-R482)
* Moved off-screen despawn checks to occur before corkscrew motion and animation updates, ensuring fireballs are removed as soon as they leave the playfield.
* Fireball rendering is now performed only in the first pass and only for active, in-playfield fireballs, avoiding duplicate rendering and improving efficiency. [[1]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L447-R482) [[2]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L493-L514)

**Enemy handling improvements:**

* Reordered enemy state handling in `handle_enemies` to match assembly flow: spawned state is handled first (including AI, collision, rendering), followed by despawned and dying states, improving clarity and correctness. [[1]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L907-R989) [[2]](diffhunk://#diff-4ec94b0001c92755903410b27b43fab564755b311f42340d0e5698b93b374418L991-L1057)
* Changed despawned enemy spawn timer logic to decrement every tick and trigger spawning only on underflow (0 → 255), not when reaching zero, for faithful assembly behavior.

**Documentation and comments:**

* Updated comments in `actors.h` to clarify the order of fireball processing steps and to describe the correct enemy spawn timer underflow behavior. [[1]](diffhunk://#diff-a30c6c4cbece57c29b6773601ca2e2d82248f3e2db97365f617cdce3445016eeR103-R107) [[2]](diffhunk://#diff-a30c6c4cbece57c29b6773601ca2e2d82248f3e2db97365f617cdce3445016eeL131-R133) [[3]](diffhunk://#diff-a30c6c4cbece57c29b6773601ca2e2d82248f3e2db97365f617cdce3445016eeL152-R154)